### PR TITLE
Fix felt_temperature import

### DIFF
--- a/custom_components/felt_temperature/sensor.py
+++ b/custom_components/felt_temperature/sensor.py
@@ -47,7 +47,7 @@ from homeassistant.helpers.event import (
     async_track_state_change_event,
     async_call_later,
 )
-from homeassistant.helpers.typing import CALLBACK_TYPE
+from homeassistant.core import CALLBACK_TYPE
 from homeassistant.util.unit_conversion import SpeedConverter, TemperatureConverter
 
 from .const import (


### PR DESCRIPTION
## Summary
- fix missing `CALLBACK_TYPE` import from homeassistant.core

## Testing
- `python -m py_compile custom_components/felt_temperature/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eff8e02f483228834220674fc4806